### PR TITLE
Add build id option for archive name

### DIFF
--- a/lib/cide/cli.rb
+++ b/lib/cide/cli.rb
@@ -123,8 +123,8 @@ module CIDE
       type: :boolean,
       default: true
 
-    method_option 'set_version',
-      desc: 'Tells cide the package version, otherwise extracted from git',
+    method_option 'set_build_id',
+      desc: 'Specifies the build id',
       default: nil
 
     # AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY and AWS_REGION need to be passed
@@ -144,14 +144,14 @@ module CIDE
 
       FileUtils.rm_rf(build_root)
 
-      version = options.set_version || (
+      build_id = options.set_build_id || (
+        timestamp = Time.now.strftime('%Y-%m-%d_%H%M%S')
         git_branch = `git symbolic-ref --short -q HEAD || echo unknown`.strip
         git_rev = `git rev-parse --short HEAD`.strip
-        "#{git_branch}-#{git_rev}"
+        "#{timestamp}.#{git_branch}-#{git_rev}"
       )
 
-      timestamp = Time.now.strftime('%Y-%m-%d_%H%M%S')
-      tar_name = "#{options.package}.#{timestamp}.#{version}.tar.gz"
+      tar_name = "#{options.package}.#{build_id}.tar.gz"
       tar_path = File.join(build_root, tar_name)
 
       banner 'Config'

--- a/lib/cide/cli.rb
+++ b/lib/cide/cli.rb
@@ -123,7 +123,7 @@ module CIDE
       type: :boolean,
       default: true
 
-    method_option 'set_build_id',
+    method_option 'build_id',
       desc: 'Specifies the build id',
       default: nil
 
@@ -144,7 +144,7 @@ module CIDE
 
       FileUtils.rm_rf(build_root)
 
-      build_id = options.set_build_id || (
+      build_id = options.build_id || (
         timestamp = Time.now.strftime('%Y-%m-%d_%H%M%S')
         git_branch = `git symbolic-ref --short -q HEAD || echo unknown`.strip
         git_rev = `git rev-parse --short HEAD`.strip


### PR DESCRIPTION
This now gives the user the possibility to specify the build id, i.e. will output an archive

 `<package>.<build-id>.tar.gz` 

(instead of `<package>.<timestamp>.<version>.tar.gz`, where version is deprecated)