### PR TITLE
cide package: add a way to inject version data

### DIFF
--- a/lib/cide/cli.rb
+++ b/lib/cide/cli.rb
@@ -158,6 +158,16 @@ module CIDE
       config = ConfigFile.load(Dir.pwd)
       say_status :config, config.inspect
 
+      version_data =
+        case config.package && config.package.add_version
+        when 'sha'
+          `git rev-parse HEAD`.strip
+        when 'short_sha'
+          `git rev-parse --short HEAD`.strip
+        when 'auto'
+          build_id
+        end
+
       ## Build ##
       banner 'Build'
       builder = Builder.new(config)
@@ -184,6 +194,15 @@ module CIDE
         guest_dir: guest_export_dir,
         host_dir: host_export_dir,
       )
+
+      ## Set version ##
+      if version_data
+        version_file = File.join(host_export_dir, '.packager', 'version')
+        FileUtils.mkdir_p(File.dirname(version_file))
+        File.open(version_file, 'w') do |f|
+          f.puts version_data
+        end
+      end
 
       # Create archive
       puts "Package: #{tar_name}"

--- a/lib/cide/config_file.rb
+++ b/lib/cide/config_file.rb
@@ -46,6 +46,12 @@ module CIDE
       attr_accessor :id
     end
 
+    class PackageConfig
+      include Virtus.model
+      include NiceInspect
+      attribute :add_version, String, required: false
+    end
+
     include Virtus.model(strict: true)
     include NiceInspect
     attribute :from, String, default: 'ubuntu'
@@ -56,6 +62,7 @@ module CIDE
     attribute :export_dir, String, required: false
     attribute :links, Array[Link], default: []
     attribute :run, Array[String], default: ['script/ci']
+    attribute :package, PackageConfig, required: false
 
     attr_reader :warnings, :errors
 

--- a/lib/cide/default_cide.yml
+++ b/lib/cide/default_cide.yml
@@ -29,5 +29,9 @@ links:
 # Sets additional environment variables
 env: {}
 
+# Packaging configuration
+package:
+#  add_version: short_sha # sha or auto
+
 # Main script to run
 run: script/ci

--- a/man/cide.yml.1.md
+++ b/man/cide.yml.1.md
@@ -50,6 +50,10 @@ export_dir:
 # CI runtime. See the Link definition.
 links: []
 
+# Setups the behaviour of the `cide package` command. See the Package
+# definition.
+package: {}
+
 # Determines what script to run to execute the tests. This is the main command
 # that is used to run the CI.
 #
@@ -151,4 +155,23 @@ env: {}
 #
 # type: string
 run: 'redis-server'
+```
+
+Package definition
+------------------
+
+A hash that changes the behavious of the `cide package command.
+
+
+```yaml
+# When defined, will generate a .packager/version file before generating
+# the archive.
+#
+# If the value is "sha" it use git's HEAD sha for the value.
+#
+# If the value is "short_sha" it will be the first 6 characteds of the sha.
+#
+# If the value is "auto" it will either be the default build ID or the one
+# passed as a command-line argument.
+add_version: auto
 ```

--- a/spec/build_config_loader_spec.rb
+++ b/spec/build_config_loader_spec.rb
@@ -19,6 +19,7 @@ describe "CIDE::ConfigFile::Loader" do
     "env" => {},
     "export_dir" => nil,
     "links" => [],
+    "package" => nil,
     "run" => ["script/ci"],
   }
 


### PR DESCRIPTION
.packager/version can contain either a git sha, short sha or the automated
build version.

/cc @Nicowcow 