### PR TITLE
Change expiration logic to use labels

### DIFF
--- a/lib/cide/docker.rb
+++ b/lib/cide/docker.rb
@@ -19,6 +19,15 @@ module CIDE
 
     class VersionError < StandardError; end
 
+    def docker_image_ids(filter_by: false)
+      args = ['--no-trunc']
+      args << ['--filter', filter_by] if filter_by
+      lines = docker('images', *args, capture: true).lines[1..-1]
+      lines
+        .map { |line| line.split(/\s+/) }
+        .map { |line| line[2] }
+    end
+
     def docker(*args, verbose: false, capture: false)
       cmd = (['docker'] + args).map(&:to_s)
       p cmd if verbose

--- a/lib/cide/dockerfile_template.erb
+++ b/lib/cide/dockerfile_template.erb
@@ -1,4 +1,7 @@
 FROM <%= from %>
+LABEL cide=""
+LABEL cide.build.complete="false"
+
 USER root
 RUN useradd -m -U -d <%= CIDE_DIR %> cide
 
@@ -55,3 +58,4 @@ USER root
 ADD . <%= CIDE_SRC_DIR %>
 RUN chown -R cide:cide <%= CIDE_DIR %>
 USER cide
+LABEL cide.build.complete="true"


### PR DESCRIPTION
I changed the expiration logic to use dockers `LABEL`s instead of pattern matching on the tag. For some unfortunate reason I cannot install docker, and hence can't test it out. @zimbatm would you mind? Let me know what you think about the changes overall.